### PR TITLE
chore: ignore .pi agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea
 
 project/db-data/
+
+.pi/


### PR DESCRIPTION
Adds `.pi/` (pi agent task/session output) to .gitignore. Also reverted a stray 4-space re-indent of `frontend/eslint.config.mjs` back to the committed Prettier formatting (whitespace-only, no content change).